### PR TITLE
chore(deps): use npm overrides to patch transitive vulns (15 -> 6, al…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,23 +160,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
@@ -1646,6 +1629,33 @@
 				"keyv": "^5.6.0"
 			}
 		},
+		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
 		"node_modules/@cacheable/utils": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
@@ -1655,6 +1665,16 @@
 			"dependencies": {
 				"hashery": "^1.5.1",
 				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/utils/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/@ckpack/vue-color": {
@@ -1959,45 +1979,6 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
-		"node_modules/@eslint/config-array/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@eslint/config-helpers": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
@@ -2121,41 +2102,41 @@
 			"license": "MIT"
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.6",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.1",
-				"@humanwhocodes/retry": "^0.3.0"
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
 			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
-		"node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
+				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -2734,23 +2715,6 @@
 				"tslib": "2"
 			}
 		},
-		"node_modules/@keyv/bigmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
-			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hashery": "^1.4.0",
-				"hookified": "^1.15.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"keyv": "^5.6.0"
-			}
-		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -2906,102 +2870,6 @@
 				"eslint": ">=10"
 			}
 		},
-		"node_modules/@nextcloud/eslint-config/node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@nextcloud/eslint-config/node_modules/eslint-plugin-jsdoc": {
-			"version": "62.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
-			"integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.86.0",
-				"@es-joy/resolve.exports": "1.2.0",
-				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.6",
-				"debug": "^4.4.3",
-				"escape-string-regexp": "^4.0.0",
-				"espree": "^11.2.0",
-				"esquery": "^1.7.0",
-				"html-entities": "^2.6.0",
-				"object-deep-merge": "^2.0.0",
-				"parse-imports-exports": "^0.2.4",
-				"semver": "^7.7.4",
-				"spdx-expression-parse": "^4.0.0",
-				"to-valid-identifier": "^1.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-			}
-		},
-		"node_modules/@nextcloud/eslint-config/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@nextcloud/eslint-config/node_modules/espree": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"acorn": "^8.16.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@nextcloud/eslint-config/node_modules/fast-xml-parser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-			"integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.2.0",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.3.0",
-				"xml-naming": "^0.1.0"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
-		},
 		"node_modules/@nextcloud/eslint-config/node_modules/semver": {
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
@@ -3014,19 +2882,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/@nextcloud/eslint-config/node_modules/strnum": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/@nextcloud/eslint-plugin": {
 			"version": "2.2.1",
@@ -3048,9 +2903,9 @@
 			}
 		},
 		"node_modules/@nextcloud/eslint-plugin/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3074,9 +2929,9 @@
 			}
 		},
 		"node_modules/@nextcloud/event-bus/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -3407,18 +3262,18 @@
 			}
 		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"detect-libc": "^1.0.3",
+				"detect-libc": "^2.0.3",
 				"is-glob": "^4.0.3",
-				"micromatch": "^4.0.5",
-				"node-addon-api": "^7.0.0"
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
@@ -3428,25 +3283,25 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"@parcel/watcher-android-arm64": "2.5.1",
-				"@parcel/watcher-darwin-arm64": "2.5.1",
-				"@parcel/watcher-darwin-x64": "2.5.1",
-				"@parcel/watcher-freebsd-x64": "2.5.1",
-				"@parcel/watcher-linux-arm-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm-musl": "2.5.1",
-				"@parcel/watcher-linux-arm64-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm64-musl": "2.5.1",
-				"@parcel/watcher-linux-x64-glibc": "2.5.1",
-				"@parcel/watcher-linux-x64-musl": "2.5.1",
-				"@parcel/watcher-win32-arm64": "2.5.1",
-				"@parcel/watcher-win32-ia32": "2.5.1",
-				"@parcel/watcher-win32-x64": "2.5.1"
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
 			}
 		},
 		"node_modules/@parcel/watcher-android-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-			"integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3465,9 +3320,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-			"integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3486,9 +3341,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-			"integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
 			"cpu": [
 				"x64"
 			],
@@ -3507,9 +3362,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-freebsd-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-			"integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
 			"cpu": [
 				"x64"
 			],
@@ -3528,9 +3383,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-			"integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3549,9 +3404,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-			"integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
 			"cpu": [
 				"arm"
 			],
@@ -3570,9 +3425,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-			"integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3591,9 +3446,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-			"integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3612,9 +3467,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-			"integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3633,9 +3488,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-			"integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
 			"cpu": [
 				"x64"
 			],
@@ -3654,9 +3509,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-			"integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3675,9 +3530,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-ia32": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-			"integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
 			"cpu": [
 				"ia32"
 			],
@@ -3696,9 +3551,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-			"integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
 			"cpu": [
 				"x64"
 			],
@@ -3898,9 +3753,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3949,29 +3804,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^9.0.0 || ^10.0.0"
-			}
-		},
-		"node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@stylistic/eslint-plugin/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/@tokenizer/token": {
@@ -4211,13 +4043,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.15.29",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-			"integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/qs": {
@@ -4245,9 +4077,9 @@
 			"peer": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-			"integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/send": {
@@ -4298,9 +4130,9 @@
 			}
 		},
 		"node_modules/@types/sizzle": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
-			"integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+			"integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
 			"license": "MIT"
 		},
 		"node_modules/@types/sockjs": {
@@ -4351,9 +4183,9 @@
 			}
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.33",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4553,45 +4385,6 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -5209,16 +5002,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			},
 			"funding": {
 				"type": "github",
@@ -5243,17 +5036,38 @@
 				}
 			}
 		},
-		"node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ajv-keywords": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
-				"ajv": "^8.8.2"
+				"ajv": "^6.9.1"
 			}
 		},
 		"node_modules/ansi-html-community": {
@@ -5271,16 +5085,13 @@
 			}
 		},
 		"node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -5567,10 +5378,14 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/base-64": {
 			"version": "1.0.0",
@@ -5745,12 +5560,16 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -6045,16 +5864,26 @@
 				"qified": "^0.10.1"
 			}
 		},
-		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+		"node_modules/cacheable/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -6234,26 +6063,26 @@
 			}
 		},
 		"node_modules/cheerio": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-			"integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+			"integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cheerio-select": "^2.1.0",
 				"dom-serializer": "^2.0.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.1.0",
-				"encoding-sniffer": "^0.2.0",
-				"htmlparser2": "^9.1.0",
-				"parse5": "^7.1.2",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0",
+				"domutils": "^3.2.2",
+				"encoding-sniffer": "^0.2.1",
+				"htmlparser2": "^10.1.0",
+				"parse5": "^7.3.0",
+				"parse5-htmlparser2-tree-adapter": "^7.1.0",
 				"parse5-parser-stream": "^7.1.2",
-				"undici": "^6.19.5",
+				"undici": "^7.19.0",
 				"whatwg-mimetype": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=18.17"
+				"node": ">=20.18.1"
 			},
 			"funding": {
 				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -6371,6 +6200,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/clone-deep/node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6428,11 +6270,15 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/comment-parser": {
 			"version": "1.4.6",
@@ -6797,9 +6643,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6810,9 +6656,9 @@
 			}
 		},
 		"node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -6841,9 +6687,9 @@
 			}
 		},
 		"node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -7088,17 +6934,14 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
-			"bin": {
-				"detect-libc": "bin/detect-libc.js"
-			},
 			"engines": {
-				"node": ">=0.10"
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -7250,9 +7093,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.4.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
+			"integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -7379,9 +7222,9 @@
 			}
 		},
 		"node_modules/encoding-sniffer": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
-			"integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+			"integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7430,9 +7273,9 @@
 			}
 		},
 		"node_modules/envinfo": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-			"integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+			"integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -7478,9 +7321,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -7521,12 +7364,13 @@
 			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7617,6 +7461,79 @@
 				"eslint": "*"
 			}
 		},
+		"node_modules/eslint-plugin-jsdoc": {
+			"version": "62.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+			"integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@es-joy/jsdoccomment": "~0.86.0",
+				"@es-joy/resolve.exports": "1.2.0",
+				"are-docs-informative": "^0.0.2",
+				"comment-parser": "1.4.6",
+				"debug": "^4.4.3",
+				"escape-string-regexp": "^4.0.0",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"html-entities": "^2.6.0",
+				"object-deep-merge": "^2.0.0",
+				"parse-imports-exports": "^0.2.4",
+				"semver": "^7.7.4",
+				"spdx-expression-parse": "^4.0.0",
+				"to-valid-identifier": "^1.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/eslint-plugin-perfectionist": {
 			"version": "5.9.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.9.0.tgz",
@@ -7667,9 +7584,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vue/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7680,17 +7597,35 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
+				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-webpack-plugin": {
@@ -7731,78 +7666,6 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
-		"node_modules/eslint/node_modules/ajv": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/eslint/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/eslint/node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -7834,52 +7697,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/eslint/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/espree": {
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -7891,19 +7708,6 @@
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^4.2.1"
 			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -7924,16 +7728,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -7947,20 +7741,10 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -8144,6 +7928,19 @@
 				"node": ">=8.6.0"
 			}
 		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8159,9 +7956,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8192,10 +7989,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-			"dev": true,
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+			"integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
 			"funding": [
 				{
 					"type": "github",
@@ -8204,7 +8000,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.1.1"
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.2.0",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.3.0",
+				"xml-naming": "^0.1.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -8221,9 +8021,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8390,16 +8190,6 @@
 				"node": ">=16"
 			}
 		},
-		"node_modules/flat-cache/node_modules/keyv": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"json-buffer": "3.0.1"
-			}
-		},
 		"node_modules/flatted": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -8555,6 +8345,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/generator-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8626,16 +8426,16 @@
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/glob-to-regex.js": {
@@ -8718,24 +8518,34 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+			"integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"fast-glob": "^3.3.3",
+				"ignore": "^7.0.5",
+				"is-path-inside": "^4.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.4.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globby/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/globjoin": {
@@ -8868,9 +8678,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -9097,17 +8907,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/html-minifier-terser/node_modules/commander": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/html-tags": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
@@ -9156,9 +8955,9 @@
 			}
 		},
 		"node_modules/htmlparser2": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
@@ -9171,8 +8970,21 @@
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.1.0",
-				"entities": "^4.5.0"
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/http-deceiver": {
@@ -9389,16 +9201,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/import-fresh/node_modules/resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/import-local": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -9417,75 +9219,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/import-local/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/import-local/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/import-local/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/import-local/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/import-local/node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/import-meta-resolve": {
@@ -9644,13 +9377,13 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.2"
+				"hasown": "^2.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -9707,14 +9440,15 @@
 			}
 		},
 		"node_modules/is-generator-function": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.0",
+				"call-bound": "^1.0.4",
+				"generator-function": "^2.0.0",
+				"get-proto": "^1.0.1",
 				"has-tostringtag": "^1.0.2",
 				"safe-regex-test": "^1.1.0"
 			},
@@ -9835,14 +9569,11 @@
 			}
 		},
 		"node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10042,9 +9773,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10068,13 +9799,13 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@keyv/serialize": "^1.1.1"
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/kind-of": {
@@ -10202,9 +9933,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10256,6 +9987,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
 			}
 		},
 		"node_modules/magic-string": {
@@ -10359,6 +10100,18 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -11169,15 +10922,16 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"license": "ISC",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -11823,9 +11577,9 @@
 			}
 		},
 		"node_modules/parse5/node_modules/entities": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-			"integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -11979,6 +11733,75 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/pkg-types": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
@@ -12090,23 +11913,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/postcss-html/node_modules/postcss-safe-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			},
-			"peerDependencies": {
-				"postcss": "^8.3.3"
-			}
-		},
 		"node_modules/postcss-media-query-parser": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -12185,30 +11991,20 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
-			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
 			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
 			},
 			"peerDependencies": {
-				"postcss": "^8.4.31"
+				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/postcss-scss": {
@@ -12792,17 +12588,6 @@
 				"strip-ansi": "^6.0.1"
 			}
 		},
-		"node_modules/renderkid/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/renderkid/node_modules/css-select": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -12902,20 +12687,6 @@
 				"entities": "^2.0.0"
 			}
 		},
-		"node_modules/renderkid/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12990,7 +12761,7 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-from": {
+		"node_modules/resolve-cwd/node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -12998,6 +12769,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/retry": {
@@ -13273,6 +13054,43 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/schema-utils/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/schema-utils/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/schema-utils/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/scule": {
 			"version": "1.3.0",
@@ -13583,14 +13401,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13652,13 +13470,16 @@
 			}
 		},
 		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/slice-ansi": {
@@ -13793,9 +13614,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -13937,41 +13758,49 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^5.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/stringify-entities": {
@@ -13989,19 +13818,16 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.2.2"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/striptags": {
@@ -14011,10 +13837,9 @@
 			"license": "MIT"
 		},
 		"node_modules/strnum": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-			"dev": true,
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -14221,9 +14046,9 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended-vue/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14257,16 +14082,6 @@
 			},
 			"peerDependencies": {
 				"stylelint": "^16.8.2 || ^17.0.0"
-			}
-		},
-		"node_modules/stylelint-scss/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint-use-logical": {
@@ -14307,6 +14122,37 @@
 				"webpack": "^5.0.0"
 			}
 		},
+		"node_modules/stylelint-webpack-plugin/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/stylelint-webpack-plugin/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
 			"version": "11.1.3",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
@@ -14329,27 +14175,6 @@
 				"hookified": "^1.15.0"
 			}
 		},
-		"node_modules/stylelint/node_modules/globby": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-			"integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/merge-streams": "^4.0.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.5",
-				"is-path-inside": "^4.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/stylelint/node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -14360,34 +14185,31 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/stylelint/node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+		"node_modules/stylelint/node_modules/postcss-safe-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18.0"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/stylelint/node_modules/string-width": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"get-east-asian-width": "^1.5.0",
-				"strip-ansi": "^7.1.2"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+			"peerDependencies": {
+				"postcss": "^8.4.31"
 			}
 		},
 		"node_modules/supports-color": {
@@ -14491,24 +14313,40 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/table/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/table/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+		"node_modules/table/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^5.0.1"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/table/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/table/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -14622,6 +14460,13 @@
 			"engines": {
 				"node": ">= 10.13.0"
 			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/thingies": {
 			"version": "2.6.0",
@@ -14997,19 +14842,19 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "6.21.3",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+			"integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.17"
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -15317,40 +15162,6 @@
 				}
 			}
 		},
-		"node_modules/url-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/url-loader/node_modules/ajv-keywords": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"ajv": "^6.9.1"
-			}
-		},
-		"node_modules/url-loader/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/url-loader/node_modules/schema-utils": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -15428,15 +15239,18 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"license": "MIT",
 			"peer": true,
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/vary": {
@@ -15529,51 +15343,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
-			}
-		},
-		"node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/vue-eslint-parser/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/vue-eslint-parser/node_modules/semver": {
@@ -15795,6 +15564,21 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/webdav/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/webdav/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
 		"node_modules/webdav/node_modules/entities": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -15807,39 +15591,20 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
-		"node_modules/webdav/node_modules/fast-xml-parser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-			"integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
+		"node_modules/webdav/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
 			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.2.0",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.3.0",
-				"xml-naming": "^0.1.0"
+				"brace-expansion": "^2.0.2"
 			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/webdav/node_modules/strnum": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/webpack": {
 			"version": "5.107.2",
@@ -16086,6 +15851,20 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/picomatch": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -16145,6 +15924,30 @@
 			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
 			"license": "MIT"
 		},
+		"node_modules/webpack/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/webpack/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/webpack/node_modules/mime-db": {
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -16186,6 +15989,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
 			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16222,9 +16026,9 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16347,6 +16151,13 @@
 			"engines": {
 				"node": ">=0.4"
 			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,10 @@
 		"webpack": "^5.107.2",
 		"webpack-cli": "^6.0.1",
 		"webpack-merge": "^6.0.1"
+	},
+	"overrides": {
+		"elliptic": "^6.6.1",
+		"fast-xml-parser": "^5.0.0",
+		"uuid": "^11.1.1"
 	}
 }


### PR DESCRIPTION
…l low)

npm audit on a fresh install reported 15 vulnerabilities (1 critical, 3 high, 6 moderate, 5 low). Most are transitive in dev-build tooling and don't ship to users (the webpack bundle going to the appstore doesn't contain elliptic, uuid, fast-xml-parser, etc.) — but it's worth fixing what we can to keep the audit signal clean.

Two-step fix:

1. `npm audit fix` — non-breaking patches for ajv, fast-uri, lodash, undici. Cleared 4 (incl. all the high/critical ones).

2. `overrides` block — force-patch three transitive packages whose parents haven't released a version that pulls in the patched leaf:
   - elliptic       ^6.6.1   (closes the audit DB's *known* boundary,
                              though see below)
   - fast-xml-parser ^5.0.0  (closes the critical XMLBuilder advisories
                              via @nextcloud/eslint-plugin)
   - uuid           ^11.1.1  (closes the buf-bounds-check advisory via
                              the webpack-dev-server -> sockjs -> uuid
                              chain, which we don't actually exercise
                              since the project never runs the dev server)

Result: 15 -> 6, all 6 LOW severity, all in the elliptic transitive chain (elliptic, browserify-sign, create-ecdh, crypto-browserify, node-polyfill-webpack-plugin, @nextcloud/webpack-vue-config). These will remain until upstream `elliptic` cuts >6.6.1 — the GHSA-848j-6mx2 advisory range is `<=6.6.1`, meaning even the latest patch is on the boundary, and the issue is in the algorithm implementation itself (not a quick patch). Tracked by node-polyfill-webpack-plugin's chain through @nextcloud/webpack-vue-config which pins
node-polyfill-webpack-plugin as a peer.