### PR TITLE
chore(renovate): pin PHP floor and cap phpunit at <12

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,17 @@
       "enabled": false
     },
     {
+      "description": "Don't bump the PHP floor — composer.json `php ^8.2` is a deliberate min-version statement tied to the Nextcloud versions we support, not something to drift with each new PHP release.",
+      "matchPackageNames": ["php"],
+      "matchManagers": ["composer"],
+      "enabled": false
+    },
+    {
+      "description": "Cap phpunit at <12: phpunit 12 needs PHP ^8.3 and phpunit 13 needs PHP ^8.4. Our floor is PHP 8.2. Revisit when raising the PHP minimum (which would also require bumping info.xml min-version).",
+      "matchPackageNames": ["phpunit/phpunit"],
+      "allowedVersions": "<12"
+    },
+    {
       "description": "Cap sass-loader: @nextcloud/webpack-vue-config@7.0.2 peer-pins sass-loader ^16. Remove this rule when upstream relaxes the peer.",
       "matchPackageNames": ["sass-loader"],
       "allowedVersions": "<17"


### PR DESCRIPTION
Two more dashboard items that need config, not PRs:

- `php`: `^8.2` is a deliberate floor (tied to NC29-32 compat and 8.1 being EOL since Nov 2025), not a moving target. Disable updates to composer's `php` constraint so Renovate stops trying to bump it to `^8.5.6` every time a new PHP minor drops.

- `phpunit/phpunit`: cap at <12 — phpunit 12 needs PHP ^8.3 and 13 needs PHP ^8.4. Our floor stays at 8.2. Revisit alongside any future decision to raise the PHP minimum (which would also require bumping info.xml min-version).