### PR TITLE
chore(dev): add local Nextcloud test stack

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -16,6 +16,7 @@ composer.json
 composer.lock
 coverage
 COPYING
+docker
 Makefile
 node_modules
 package.json

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,17 @@ docker-logs:
 
 # Run an occ command, e.g. `make docker-occ CMD="app:list"`.
 docker-occ:
-	$(docker_compose) exec --user www-data nextcloud php occ $(CMD)
+	$(docker_compose) exec -T --user www-data nextcloud php occ $(CMD)
 
 # Open a shell in the Nextcloud container as the web user.
 docker-shell:
 	$(docker_compose) exec --user www-data nextcloud bash
+
+# Disable every app not needed to test the app (lighter instance). Re-runnable;
+# honours APP_ID / EXTRA_APPS / KEEP_APPS. Core apps that can't be disabled stay.
+docker-minimal:
+	$(docker_compose) exec -T -e FORCE_MINIMAL=1 -e MINIMAL_APPS=true --user www-data \
+		nextcloud /docker-entrypoint-hooks.d/before-starting/enable-app.sh
 
 # Tear everything down INCLUDING data volumes (next `docker-up` is a clean install).
 docker-clean:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
 version+=master
 
+# Local Nextcloud test stack (see docker/README.md)
+compose_file=$(CURDIR)/docker/docker-compose.yml
+docker_compose=docker compose -f $(compose_file)
+
 all: dev-setup build-js-production
 
 dev-setup: clean-dev npm-init
@@ -47,6 +51,48 @@ clean:
 clean-dev: clean
 	rm -rf node_modules
 
+# --- Local Nextcloud test stack ---------------------------------------------
+
+# Create docker/.env from the example on first use (won't overwrite an existing one).
+docker-env:
+	@test -f $(CURDIR)/docker/.env || cp $(CURDIR)/docker/.env.example $(CURDIR)/docker/.env
+
+# Start the stack in the background (installs Nextcloud + enables the app on first boot).
+docker-up: docker-env
+	$(docker_compose) up -d
+
+# Stop and remove containers + network, keeping data volumes (fast to bring back up).
+docker-down:
+	$(docker_compose) down
+
+# Pause the containers without removing them.
+docker-stop:
+	$(docker_compose) stop
+
+# Restart only the Nextcloud container (e.g. after changing PHP code).
+docker-restart:
+	$(docker_compose) restart nextcloud
+
+# Show container status.
+docker-ps:
+	$(docker_compose) ps
+
+# Follow the Nextcloud logs (Ctrl-C to stop following).
+docker-logs:
+	$(docker_compose) logs -f nextcloud
+
+# Run an occ command, e.g. `make docker-occ CMD="app:list"`.
+docker-occ:
+	$(docker_compose) exec --user www-data nextcloud php occ $(CMD)
+
+# Open a shell in the Nextcloud container as the web user.
+docker-shell:
+	$(docker_compose) exec --user www-data nextcloud bash
+
+# Tear everything down INCLUDING data volumes (next `docker-up` is a clean install).
+docker-clean:
+	$(docker_compose) down -v
+
 create-tag:
 	git tag -a v$(version) -m "Tagging the $(version) release."
 	git push origin v$(version)
@@ -59,6 +105,7 @@ appstore:
 	--exclude=/build \
 	--exclude=composer.json \
 	--exclude=composer.lock \
+	--exclude=docker \
 	--exclude=docs \
 	--exclude=.drone.yml \
 	--exclude=.eslintignore \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ make docker-up      # then open http://localhost:8080  (admin / admin)
 ```
 
 See [docker/README.md](docker/README.md) for details (target versions, minimal
-mode, reuse for other apps, troubleshooting).
+mode, auto-creating the external storage, reuse for other apps, troubleshooting).
 
 Here’s an improved and more professional version of that README section:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ make build-js-production
 
 * Enable the app in the Apps section of your Nextcloud.
 
+### Local testing with Docker
+
+No Nextcloud to test against? This repo ships a disposable Docker Compose stack
+(Nextcloud + PostgreSQL + Redis) that mounts the app and enables it automatically:
+
+```
+make docker-up      # then open http://localhost:8080  (admin / admin)
+```
+
+See [docker/README.md](docker/README.md) for details (target versions, minimal
+mode, reuse for other apps, troubleshooting).
+
 Here’s an improved and more professional version of that README section:
 
 ---

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -31,15 +31,30 @@ KEEP_APPS=
 # appending " loglevel=0". Empty it out to disable the gateway backend.
 NC_CONFIG=cidgravity_gateway_external_storage_enabled=true
 
-# --- Optional: auto-create ONE external storage mount on boot ----------------
-# Leave EXT_STORAGE_MOUNT empty to skip (and add the storage manually in the UI).
-# Set it to a mount-point name to have it created automatically (idempotent).
-# Values in EXT_STORAGE_CONFIG must not contain spaces. Pre-filled for a
-# CIDgravity mount -- just set the mount name and your real account credentials.
-EXT_STORAGE_MOUNT=
-EXT_STORAGE_BACKEND=cidgravity
-EXT_STORAGE_AUTH=password::password
-EXT_STORAGE_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+# --- Auto-create external storage mounts on boot -----------------------------
+# Up to 3 mounts via indexed slots EXT_STORAGE_<i>_{MOUNT,BACKEND,AUTH,CONFIG}.
+# Creation stops at the first empty _MOUNT, so empty a slot's _MOUNT to skip it.
+# _CONFIG is space-separated key=value pairs (no spaces in values). Mounts are
+# system mounts available to all users; created idempotently (existing = kept).
+# Fill in your real CIDgravity credentials / gateway URLs before use.
+
+# Slot 1: plain CIDgravity backend (talks to another Nextcloud).
+EXT_STORAGE_1_MOUNT=CIDgravity
+EXT_STORAGE_1_BACKEND=cidgravity
+EXT_STORAGE_1_AUTH=password::password
+EXT_STORAGE_1_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+
+# Slot 2: CIDgravity Gateway backend (WebDAV + metadata endpoint).
+EXT_STORAGE_2_MOUNT=CIDgravityGateway
+EXT_STORAGE_2_BACKEND=cidgravityGateway
+EXT_STORAGE_2_AUTH=password::password
+EXT_STORAGE_2_CONFIG=host=https://gateway.example.com secure=true metadata_endpoint=https://gateway.example.com/metadata default_ipfs_gateway=https://ipfs.io/ipfs auto_create_user_folder=true user=YOUR_USER password=YOUR_PASSWORD
+
+# Slot 3: spare — set _MOUNT to use it.
+EXT_STORAGE_3_MOUNT=
+EXT_STORAGE_3_BACKEND=cidgravity
+EXT_STORAGE_3_AUTH=password::password
+EXT_STORAGE_3_CONFIG=
 
 # --- Admin account created on first boot ---
 NEXTCLOUD_ADMIN_USER=admin

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,6 +23,14 @@ MINIMAL_APPS=true
 # e.g. "files_versions files_trashbin" if you want to test versioning/trash.
 KEEP_APPS=
 
+# --- Nextcloud system config to set on boot ----------------------------------
+# Space-separated key=value pairs (no spaces in values). Type is inferred:
+# true/false -> boolean, digits -> integer, else string. Applied every boot.
+# Enabled by default so BOTH external-storage backends (CIDgravity and the
+# CIDgravity Gateway) are available to test. Add more keys as needed, e.g.
+# appending " loglevel=0". Empty it out to disable the gateway backend.
+NC_CONFIG=cidgravity_gateway_external_storage_enabled=true
+
 # --- Optional: auto-create ONE external storage mount on boot ----------------
 # Leave EXT_STORAGE_MOUNT empty to skip (and add the storage manually in the UI).
 # Set it to a mount-point name to have it created automatically (idempotent).

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,6 +15,14 @@ APP_ID=cidgravity
 # CIDgravity registers an External Storage backend, so it needs files_external.
 EXTRA_APPS=files_external
 
+# Lighter instance: disable every default/onboarding/sharing app that isn't
+# needed to test APP_ID. Applied on fresh install; re-run with `make docker-minimal`.
+# Core apps that can't be disabled (files, dav, settings, theming) always stay.
+MINIMAL_APPS=true
+# Extra apps to KEEP enabled beyond APP_ID + EXTRA_APPS (space-separated).
+# e.g. "files_versions files_trashbin" if you want to test versioning/trash.
+KEEP_APPS=
+
 # --- Admin account created on first boot ---
 NEXTCLOUD_ADMIN_USER=admin
 NEXTCLOUD_ADMIN_PASSWORD=admin

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,6 +23,16 @@ MINIMAL_APPS=true
 # e.g. "files_versions files_trashbin" if you want to test versioning/trash.
 KEEP_APPS=
 
+# --- Optional: auto-create ONE external storage mount on boot ----------------
+# Leave EXT_STORAGE_MOUNT empty to skip (and add the storage manually in the UI).
+# Set it to a mount-point name to have it created automatically (idempotent).
+# Values in EXT_STORAGE_CONFIG must not contain spaces. Pre-filled for a
+# CIDgravity mount -- just set the mount name and your real account credentials.
+EXT_STORAGE_MOUNT=
+EXT_STORAGE_BACKEND=cidgravity
+EXT_STORAGE_AUTH=password::password
+EXT_STORAGE_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+
 # --- Admin account created on first boot ---
 NEXTCLOUD_ADMIN_USER=admin
 NEXTCLOUD_ADMIN_PASSWORD=admin

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,28 @@
+# Copy to `.env` (gitignored) and tweak as needed.
+
+# Nextcloud image tag. This app supports 29..32 (appinfo/info.xml).
+# Do not set above 32 or the app will refuse to enable. Change + `down -v`
+# between runs to test other versions in the supported range.
+NEXTCLOUD_VERSION=32
+
+# Host port -> Nextcloud (http://localhost:<NC_PORT>).
+NC_PORT=8080
+
+# --- App under test (the only values to change when reusing for another app) ---
+# Must match <id> in the app's appinfo/info.xml.
+APP_ID=cidgravity
+# Space-separated apps to enable BEFORE the app under test (its dependencies).
+# CIDgravity registers an External Storage backend, so it needs files_external.
+EXTRA_APPS=files_external
+
+# --- Admin account created on first boot ---
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=admin
+
+# Comma/space separated. localhost is enough for local testing.
+NEXTCLOUD_TRUSTED_DOMAINS=localhost
+
+# --- PostgreSQL ---
+POSTGRES_DB=nextcloud
+POSTGRES_USER=nextcloud
+POSTGRES_PASSWORD=nextcloud

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+# Local overrides — never commit credentials/ports.
+.env

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,28 +78,37 @@ backend remains).
 - For a quick one-off change to the running instance, use `make docker-occ
   CMD="config:system:set …"` — it takes effect immediately, no recreate.
 
-## Auto-create the external storage
+## Auto-create external storage mounts
 
-Instead of adding the CIDgravity storage by hand in the UI every time, you can
-have one mount created automatically on boot. Set these in `.env`:
+Instead of adding storage by hand in the UI every time, you can have mounts
+created automatically on boot. Define up to 3 in `.env` via indexed slots
+`EXT_STORAGE_<i>_{MOUNT,BACKEND,AUTH,CONFIG}`. `.env.example` ships two by
+default — one `cidgravity` and one `cidgravityGateway`:
 
 ```sh
-EXT_STORAGE_MOUNT=CIDgravity      # mount-point name (empty = don't create)
-EXT_STORAGE_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+EXT_STORAGE_1_MOUNT=CIDgravity
+EXT_STORAGE_1_BACKEND=cidgravity
+EXT_STORAGE_1_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+
+EXT_STORAGE_2_MOUNT=CIDgravityGateway
+EXT_STORAGE_2_BACKEND=cidgravityGateway
+EXT_STORAGE_2_CONFIG=host=https://gateway.example.com secure=true metadata_endpoint=https://gateway.example.com/metadata default_ipfs_gateway=https://ipfs.io/ipfs auto_create_user_folder=true user=YOUR_USER password=YOUR_PASSWORD
 ```
 
-`EXT_STORAGE_BACKEND` (`cidgravity`) and `EXT_STORAGE_AUTH` (`password::password`)
-default correctly; the config keys match the CIDgravity backend
-([CIDgravityBackendService](../lib/Service/Backend/CIDgravityBackendService.php)).
-The mount is a **system mount applicable to all users** and is created
-idempotently — re-runs leave an existing mount untouched.
+Config keys match the backends
+([CIDgravityBackendService](../lib/Service/Backend/CIDgravityBackendService.php),
+[CIDgravityGatewayBackendService](../lib/Service/Backend/CIDgravityGatewayBackendService.php)).
+`_AUTH` defaults to `password::password`. Each mount is a **system mount
+available to all users** and is created idempotently — existing mounts are kept.
 
 Notes:
-- Leave `EXT_STORAGE_MOUNT` empty to skip and configure manually instead.
-- Values in `EXT_STORAGE_CONFIG` must not contain spaces.
-- Credentials live only in your local (gitignored) `.env`.
-- The mechanism is generic — point `EXT_STORAGE_BACKEND`/`_AUTH`/`_CONFIG` at any
-  external-storage backend to reuse it for another app.
+- Creation stops at the first empty `_MOUNT`, so empty a slot to skip it.
+- Fill in your real credentials / gateway URLs — the defaults are placeholders.
+- Values in `_CONFIG` must not contain spaces. Credentials live only in your
+  local (gitignored) `.env`.
+- Generic — point a slot's `_BACKEND`/`_AUTH`/`_CONFIG` at any external-storage
+  backend to reuse for another app. Need more than 3? Add slots to both `.env`
+  and the `environment:` block in `docker-compose.yml`.
 - Verify with `make docker-occ CMD="files_external:list"`.
 
 ## Minimal instance

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,14 +52,31 @@ From the repo root (these wrap the `docker compose` commands below):
 ## Testing the app
 
 1. Log in as admin.
-2. Go to **Settings → Administration → External storage** — the **CIDgravity**
-   backend should appear in the "Add storage" dropdown.
-3. The optional gateway backend only shows up after enabling its flag:
+2. Go to **Settings → Administration → External storage** — both the
+   **CIDgravity** and **CIDgravity Gateway** backends appear in the "Add storage"
+   dropdown. (The gateway is enabled by default via `NC_CONFIG`; see below to
+   turn it off.)
 
-   ```sh
-   docker compose exec --user www-data nextcloud \
-     php occ config:system:set cidgravity_gateway_external_storage_enabled --value=true --type=boolean
-   ```
+## Nextcloud system config
+
+To change Nextcloud system config without editing `config.php` inside the
+container, list `key=value` pairs in `NC_CONFIG`; they're applied on every boot.
+Type is inferred — `true`/`false` → boolean, digits → integer, otherwise string.
+By default it enables the gateway backend; append more keys as needed:
+
+```sh
+NC_CONFIG=cidgravity_gateway_external_storage_enabled=true loglevel=0
+```
+
+Empty `NC_CONFIG` to disable the gateway backend (only the plain CIDgravity
+backend remains).
+
+- Values must not contain spaces.
+- **Changing `.env` needs a recreate, not a restart:** run `make docker-up`
+  again (Compose recreates the container with the new env). `make docker-restart`
+  keeps the old values.
+- For a quick one-off change to the running instance, use `make docker-occ
+  CMD="config:system:set …"` — it takes effect immediately, no recreate.
 
 ## Auto-create the external storage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -46,6 +46,7 @@ From the repo root (these wrap the `docker compose` commands below):
 | `make docker-logs` | Follow the Nextcloud logs |
 | `make docker-occ CMD="app:list"` | Run an occ command |
 | `make docker-shell` | Open a shell in the Nextcloud container as `www-data` |
+| `make docker-minimal` | Disable every app not needed to test the app (lighter instance) |
 | `make docker-clean` | Tear down **including data volumes** (next up = clean install) |
 
 ## Testing the app
@@ -59,6 +60,27 @@ From the repo root (these wrap the `docker compose` commands below):
    docker compose exec --user www-data nextcloud \
      php occ config:system:set cidgravity_gateway_external_storage_enabled --value=true --type=boolean
    ```
+
+## Minimal instance
+
+To keep the instance light, `MINIMAL_APPS=true` (the default in `.env.example`)
+disables every default/onboarding/sharing app that isn't needed to test the app
+— dashboard, firstrunwizard, activity, photos, text, files_sharing, etc. Only
+the app under test (`APP_ID`), its dependencies (`EXTRA_APPS`), anything in
+`KEEP_APPS`, and Nextcloud's always-enabled core (files, dav, settings, theming,
+…) stay enabled.
+
+- It runs automatically on a **fresh install**. Re-run anytime with
+  `make docker-minimal` (idempotent).
+- Keep extra apps by listing them in `KEEP_APPS`, e.g.
+  `KEEP_APPS=files_versions files_trashbin`.
+- Turn it off with `MINIMAL_APPS=false` to get a stock Nextcloud.
+- Apps are *disabled*, not removed: shipped apps live in the image and would be
+  restored on a clean reinstall, so disabling is the right (and reversible) lever.
+
+> If you already have a `docker/.env` from before this option existed, add
+> `MINIMAL_APPS=true` to it (or delete `docker/.env` and re-run `make docker-up`
+> to regenerate it from `.env.example`).
 
 ## Frontend dev loop
 
@@ -124,4 +146,8 @@ is mounted at `custom_apps/${APP_ID}` and enabled by id.
 - **"Cannot read app" / permission errors on the mount.** `www-data` (uid 33)
   inside the container must be able to read the checkout. Make it world-readable:
   `chmod -R a+rX ..` (run from this folder).
+- **Edited `hooks/enable-app.sh` but nothing changed?** Single-file bind mounts
+  pin the file's inode, so a *running* container keeps the old copy. Recreate it:
+  `docker compose up -d --force-recreate nextcloud` (or `make docker-down && make docker-up`).
+  Editing the app's own PHP/JS is unaffected — that's a directory mount and updates live.
 - **Port already in use.** Change `NC_PORT` in `.env`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,6 +61,30 @@ From the repo root (these wrap the `docker compose` commands below):
      php occ config:system:set cidgravity_gateway_external_storage_enabled --value=true --type=boolean
    ```
 
+## Auto-create the external storage
+
+Instead of adding the CIDgravity storage by hand in the UI every time, you can
+have one mount created automatically on boot. Set these in `.env`:
+
+```sh
+EXT_STORAGE_MOUNT=CIDgravity      # mount-point name (empty = don't create)
+EXT_STORAGE_CONFIG=host=https://nextcloud.twinquasar.io secure=true root=PublicFilecoin default_ipfs_gateway=https://ipfs.io/ipfs user=YOUR_USER password=YOUR_PASSWORD
+```
+
+`EXT_STORAGE_BACKEND` (`cidgravity`) and `EXT_STORAGE_AUTH` (`password::password`)
+default correctly; the config keys match the CIDgravity backend
+([CIDgravityBackendService](../lib/Service/Backend/CIDgravityBackendService.php)).
+The mount is a **system mount applicable to all users** and is created
+idempotently — re-runs leave an existing mount untouched.
+
+Notes:
+- Leave `EXT_STORAGE_MOUNT` empty to skip and configure manually instead.
+- Values in `EXT_STORAGE_CONFIG` must not contain spaces.
+- Credentials live only in your local (gitignored) `.env`.
+- The mechanism is generic — point `EXT_STORAGE_BACKEND`/`_AUTH`/`_CONFIG` at any
+  external-storage backend to reuse it for another app.
+- Verify with `make docker-occ CMD="files_external:list"`.
+
 ## Minimal instance
 
 To keep the instance light, `MINIMAL_APPS=true` (the default in `.env.example`)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,127 @@
+# Local Nextcloud test stack
+
+A disposable Docker Compose stack to test this app against a real Nextcloud,
+without maintaining a permanent dev server.
+
+**Services:** Nextcloud (Apache) + PostgreSQL + Redis — a standard, production-ish
+setup. The repo is mounted into `custom_apps/` and the app is enabled
+automatically on first boot.
+
+## Requirements
+
+- Docker + the Docker Compose plugin (`docker compose`, v2).
+- The app's frontend must be built (the `js/` folder must exist). It is already
+  built in a normal checkout; rebuild with `npm ci && npm run build` from the
+  repo root if it's missing.
+
+## Quick start
+
+```sh
+cd docker
+cp .env.example .env          # optionally tweak version / port / credentials
+docker compose up -d          # first boot installs NC + enables files_external + cidgravity
+```
+
+Then open <http://localhost:8080> and log in with `admin` / `admin`
+(or whatever you set in `.env`).
+
+First boot pulls images and installs Nextcloud, so it takes a minute or two.
+Follow along with:
+
+```sh
+docker compose logs -f nextcloud      # watch for the [enable-app] lines
+```
+
+## Make shortcuts
+
+From the repo root (these wrap the `docker compose` commands below):
+
+| Target | Action |
+| --- | --- |
+| `make docker-up` | Create `docker/.env` if missing, then start the stack in the background |
+| `make docker-down` | Stop + remove containers and network (keeps data volumes) |
+| `make docker-stop` | Pause containers without removing them |
+| `make docker-restart` | Restart just the Nextcloud container (e.g. after PHP changes) |
+| `make docker-ps` | Show container status |
+| `make docker-logs` | Follow the Nextcloud logs |
+| `make docker-occ CMD="app:list"` | Run an occ command |
+| `make docker-shell` | Open a shell in the Nextcloud container as `www-data` |
+| `make docker-clean` | Tear down **including data volumes** (next up = clean install) |
+
+## Testing the app
+
+1. Log in as admin.
+2. Go to **Settings → Administration → External storage** — the **CIDgravity**
+   backend should appear in the "Add storage" dropdown.
+3. The optional gateway backend only shows up after enabling its flag:
+
+   ```sh
+   docker compose exec --user www-data nextcloud \
+     php occ config:system:set cidgravity_gateway_external_storage_enabled --value=true --type=boolean
+   ```
+
+## Frontend dev loop
+
+The repo is bind-mounted, so rebuilt assets are picked up live. From the repo root:
+
+```sh
+npm run watch                 # rebuilds js/ on change
+```
+
+Then hard-refresh the browser (Ctrl/Cmd+Shift+R) to bypass cached assets.
+After changing **PHP** code, reload the app:
+
+```sh
+docker compose exec --user www-data nextcloud php occ app:disable cidgravity
+docker compose exec --user www-data nextcloud php occ app:enable  cidgravity
+```
+
+## Useful commands
+
+```sh
+# Run any occ command
+docker compose exec --user www-data nextcloud php occ <command>
+
+# Confirm the app is enabled
+docker compose exec --user www-data nextcloud php occ app:list | grep cidgravity
+
+# Stop (keep data)
+docker compose down
+
+# Full reset — wipe NC install + DB, next `up` is a clean install
+docker compose down -v
+```
+
+## Testing other Nextcloud versions
+
+The app declares support for Nextcloud 29–32. To test another version, set
+`NEXTCLOUD_VERSION` in `.env`, then recreate from a clean install:
+
+```sh
+docker compose down -v
+NEXTCLOUD_VERSION=31 docker compose up -d   # or just edit .env
+```
+
+> In-place version *upgrades* (e.g. bumping the var without `down -v`) only work
+> one major at a time and aren't the point here — wipe and reinstall instead.
+
+## Reusing this stack for another app
+
+This folder is app-agnostic. Copy `docker/` into another Nextcloud app repo and
+change two values in `.env`:
+
+- `APP_ID` → that app's `<id>` from its `appinfo/info.xml`
+- `EXTRA_APPS` → its dependency apps (space-separated; empty if none)
+
+Nothing in `docker-compose.yml` or `hooks/enable-app.sh` needs editing — the app
+is mounted at `custom_apps/${APP_ID}` and enabled by id.
+
+## Troubleshooting
+
+- **App won't enable / not listed.** Check `docker compose logs nextcloud` for the
+  `[enable-app]` output. Most common causes: `js/` not built, or
+  `NEXTCLOUD_VERSION` outside the app's min/max range.
+- **"Cannot read app" / permission errors on the mount.** `www-data` (uid 33)
+  inside the container must be able to read the checkout. Make it world-readable:
+  `chmod -R a+rX ..` (run from this folder).
+- **Port already in use.** Change `NC_PORT` in `.env`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,73 @@
+# Local, disposable Nextcloud test stack.
+#
+# Standard 3-service setup (Nextcloud + PostgreSQL + Redis) that mounts the app
+# living in this repo into custom_apps/ and auto-enables it on boot.
+#
+# Reuse for another Nextcloud app: copy this `docker/` folder into that repo and
+# change APP_ID / EXTRA_APPS in `.env`. Nothing below needs editing.
+#
+#   cp .env.example .env
+#   docker compose up -d
+#   open http://localhost:8080   (admin / admin)
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-nextcloud}
+      POSTGRES_USER: ${POSTGRES_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nextcloud}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nextcloud} -d ${POSTGRES_DB:-nextcloud}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --save "" --appendonly no
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  nextcloud:
+    image: nextcloud:${NEXTCLOUD_VERSION:-32}-apache
+    restart: unless-stopped
+    ports:
+      - "${NC_PORT:-8080}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      # --- Non-interactive auto-install (official image) ---
+      POSTGRES_HOST: db
+      POSTGRES_DB: ${POSTGRES_DB:-nextcloud}
+      POSTGRES_USER: ${POSTGRES_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nextcloud}
+      REDIS_HOST: redis
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_ADMIN_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_ADMIN_PASSWORD:-admin}
+      NEXTCLOUD_TRUSTED_DOMAINS: ${NEXTCLOUD_TRUSTED_DOMAINS:-localhost}
+      # --- Read by the enable-app.sh entrypoint hook (runs inside this container) ---
+      APP_ID: ${APP_ID:-cidgravity}
+      EXTRA_APPS: ${EXTRA_APPS:-files_external}
+    volumes:
+      # Persist the Nextcloud install (config, data, shipped apps) across restarts.
+      - nextcloud_data:/var/www/html
+      # Mount THIS repo as the app under test. Requires the checkout to be
+      # world-readable so www-data can read it (normal for a fresh clone).
+      - ../:/var/www/html/custom_apps/${APP_ID:-cidgravity}
+      # Auto-enable EXTRA_APPS + APP_ID on every boot (idempotent).
+      - ./hooks/enable-app.sh:/docker-entrypoint-hooks.d/before-starting/enable-app.sh:ro
+
+volumes:
+  db_data:
+  nextcloud_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,11 +76,20 @@ services:
       KEEP_APPS: ${KEEP_APPS:-}
       # Optional: Nextcloud system config to set on boot (key=value pairs).
       NC_CONFIG: ${NC_CONFIG:-}
-      # Optional: auto-create one external storage mount on boot.
-      EXT_STORAGE_MOUNT: ${EXT_STORAGE_MOUNT:-}
-      EXT_STORAGE_BACKEND: ${EXT_STORAGE_BACKEND:-cidgravity}
-      EXT_STORAGE_AUTH: ${EXT_STORAGE_AUTH:-password::password}
-      EXT_STORAGE_CONFIG: ${EXT_STORAGE_CONFIG:-}
+      # Optional: auto-create external storage mounts on boot (up to 3 slots;
+      # empty _MOUNT = skip). Driven from .env.
+      EXT_STORAGE_1_MOUNT: ${EXT_STORAGE_1_MOUNT:-}
+      EXT_STORAGE_1_BACKEND: ${EXT_STORAGE_1_BACKEND:-cidgravity}
+      EXT_STORAGE_1_AUTH: ${EXT_STORAGE_1_AUTH:-password::password}
+      EXT_STORAGE_1_CONFIG: ${EXT_STORAGE_1_CONFIG:-}
+      EXT_STORAGE_2_MOUNT: ${EXT_STORAGE_2_MOUNT:-}
+      EXT_STORAGE_2_BACKEND: ${EXT_STORAGE_2_BACKEND:-cidgravity}
+      EXT_STORAGE_2_AUTH: ${EXT_STORAGE_2_AUTH:-password::password}
+      EXT_STORAGE_2_CONFIG: ${EXT_STORAGE_2_CONFIG:-}
+      EXT_STORAGE_3_MOUNT: ${EXT_STORAGE_3_MOUNT:-}
+      EXT_STORAGE_3_BACKEND: ${EXT_STORAGE_3_BACKEND:-cidgravity}
+      EXT_STORAGE_3_AUTH: ${EXT_STORAGE_3_AUTH:-password::password}
+      EXT_STORAGE_3_CONFIG: ${EXT_STORAGE_3_CONFIG:-}
     volumes:
       # Persist the Nextcloud install (config, data, shipped apps) across restarts.
       - nextcloud_data:/var/www/html

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       EXTRA_APPS: ${EXTRA_APPS:-files_external}
       MINIMAL_APPS: ${MINIMAL_APPS:-false}
       KEEP_APPS: ${KEEP_APPS:-}
+      # Optional: Nextcloud system config to set on boot (key=value pairs).
+      NC_CONFIG: ${NC_CONFIG:-}
       # Optional: auto-create one external storage mount on boot.
       EXT_STORAGE_MOUNT: ${EXT_STORAGE_MOUNT:-}
       EXT_STORAGE_BACKEND: ${EXT_STORAGE_BACKEND:-cidgravity}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       EXTRA_APPS: ${EXTRA_APPS:-files_external}
       MINIMAL_APPS: ${MINIMAL_APPS:-false}
       KEEP_APPS: ${KEEP_APPS:-}
+      # Optional: auto-create one external storage mount on boot.
+      EXT_STORAGE_MOUNT: ${EXT_STORAGE_MOUNT:-}
+      EXT_STORAGE_BACKEND: ${EXT_STORAGE_BACKEND:-cidgravity}
+      EXT_STORAGE_AUTH: ${EXT_STORAGE_AUTH:-password::password}
+      EXT_STORAGE_CONFIG: ${EXT_STORAGE_CONFIG:-}
     volumes:
       # Persist the Nextcloud install (config, data, shipped apps) across restarts.
       - nextcloud_data:/var/www/html

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,19 @@ services:
   nextcloud:
     image: nextcloud:${NEXTCLOUD_VERSION:-32}-apache
     restart: unless-stopped
+    # Bind-mounting the app into custom_apps/<APP_ID> makes Docker create the
+    # parent custom_apps as root:root. The image only fixes its ownership when
+    # it's empty, so it stays root and breaks the App Store / Settings -> Apps
+    # ("Cannot write into apps directory"). Chown it as root here, then hand off
+    # to the stock entrypoint (which runs the hooks as www-data). "$$@" passes
+    # the image's default command (apache2-foreground) through untouched.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - chown www-data:www-data /var/www/html/custom_apps 2>/dev/null || true; exec /entrypoint.sh "$$@"
+      - --
+    # Overriding entrypoint clears the image's default CMD, so restore it.
+    command: ["apache2-foreground"]
     ports:
       - "${NC_PORT:-8080}:80"
     depends_on:
@@ -59,13 +72,18 @@ services:
       # --- Read by the enable-app.sh entrypoint hook (runs inside this container) ---
       APP_ID: ${APP_ID:-cidgravity}
       EXTRA_APPS: ${EXTRA_APPS:-files_external}
+      MINIMAL_APPS: ${MINIMAL_APPS:-false}
+      KEEP_APPS: ${KEEP_APPS:-}
     volumes:
       # Persist the Nextcloud install (config, data, shipped apps) across restarts.
       - nextcloud_data:/var/www/html
       # Mount THIS repo as the app under test. Requires the checkout to be
       # world-readable so www-data can read it (normal for a fresh clone).
       - ../:/var/www/html/custom_apps/${APP_ID:-cidgravity}
-      # Auto-enable EXTRA_APPS + APP_ID on every boot (idempotent).
+      # Auto-enable EXTRA_APPS + APP_ID. Wired into both hooks (idempotent):
+      # post-installation fires once after a fresh install; before-starting runs
+      # on every boot (covers restarts and reused volumes).
+      - ./hooks/enable-app.sh:/docker-entrypoint-hooks.d/post-installation/enable-app.sh:ro
       - ./hooks/enable-app.sh:/docker-entrypoint-hooks.d/before-starting/enable-app.sh:ro
 
 volumes:

--- a/docker/hooks/enable-app.sh
+++ b/docker/hooks/enable-app.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Nextcloud "before-starting" entrypoint hook.
+#
+# Runs as root on every container boot, after the image has finished any
+# install/upgrade step and just before Apache starts. We drop to www-data to
+# run occ. Everything here is idempotent, so it is safe to run on each boot
+# (fresh install, restart, or existing volume + newly added app).
+#
+# APP_ID and EXTRA_APPS are passed in via the container environment.
+set -eu
+
+occ() { runuser -u www-data -- php /var/www/html/occ "$@"; }
+
+# Nextcloud may not be installed yet (e.g. fresh volume taking the web-wizard
+# path instead of auto-install). Skip cleanly rather than erroring.
+if ! occ status --output=json 2>/dev/null | grep -q '"installed":true'; then
+	echo "[enable-app] Nextcloud not installed yet; skipping app enable."
+	exit 0
+fi
+
+# Enable dependency apps first (e.g. files_external for CIDgravity).
+for app in ${EXTRA_APPS:-}; do
+	echo "[enable-app] enabling dependency app: $app"
+	occ app:enable "$app" || echo "[enable-app] could not enable dependency: $app"
+done
+
+# Enable the app under test.
+if [ -n "${APP_ID:-}" ]; then
+	echo "[enable-app] enabling app under test: $APP_ID"
+	if ! occ app:enable "$APP_ID"; then
+		echo "[enable-app] FAILED to enable '$APP_ID'."
+		echo "[enable-app] Is the frontend built (js/ present) and the Nextcloud version within the app's min/max range?"
+	fi
+fi

--- a/docker/hooks/enable-app.sh
+++ b/docker/hooks/enable-app.sh
@@ -1,34 +1,61 @@
 #!/bin/sh
-# Nextcloud "before-starting" entrypoint hook.
+# Nextcloud entrypoint hook: enable the app under test (+ its deps) and,
+# optionally, disable everything else for a lighter test instance.
 #
-# Runs as root on every container boot, after the image has finished any
-# install/upgrade step and just before Apache starts. We drop to www-data to
-# run occ. Everything here is idempotent, so it is safe to run on each boot
-# (fresh install, restart, or existing volume + newly added app).
+# Mounted into BOTH post-installation and before-starting:
+#   - post-installation runs once, right after a fresh unattended install.
+#   - before-starting runs on every boot (covers restarts and existing volumes).
+# Both are idempotent. Also runnable on demand via `make docker-minimal`
+# (which sets FORCE_MINIMAL=1).
 #
-# APP_ID and EXTRA_APPS are passed in via the container environment.
+# NOTE: the official image runs hooks as www-data (via `su -p www-data`), so we
+# call occ directly here -- do NOT wrap it in runuser/su (that needs root and
+# would fail). custom_apps ownership is fixed as root in the compose entrypoint.
+#
+# Env (from docker-compose.yml): APP_ID, EXTRA_APPS, MINIMAL_APPS, KEEP_APPS.
 set -eu
 
-occ() { runuser -u www-data -- php /var/www/html/occ "$@"; }
+occ() { php /var/www/html/occ "$@"; }
 
-# Nextcloud may not be installed yet (e.g. fresh volume taking the web-wizard
-# path instead of auto-install). Skip cleanly rather than erroring.
-if ! occ status --output=json 2>/dev/null | grep -q '"installed":true'; then
-	echo "[enable-app] Nextcloud not installed yet; skipping app enable."
-	exit 0
-fi
+# The install state isn't always settled the instant a hook fires, so wait
+# (bounded) rather than giving up immediately. If it never reports installed
+# (e.g. the web-wizard path was chosen), skip cleanly without blocking boot.
+i=0
+until occ status --output=json 2>/dev/null | grep -q '"installed":true'; do
+	i=$((i + 1))
+	if [ "$i" -ge 30 ]; then
+		echo "[enable-app] Nextcloud not installed after waiting; skipping."
+		echo "[enable-app] Enable manually with: make docker-occ CMD=\"app:enable ${APP_ID:-<app>}\""
+		exit 0
+	fi
+	sleep 1
+done
 
-# Enable dependency apps first (e.g. files_external for CIDgravity).
+# Enable dependency apps first, then the app under test.
 for app in ${EXTRA_APPS:-}; do
 	echo "[enable-app] enabling dependency app: $app"
 	occ app:enable "$app" || echo "[enable-app] could not enable dependency: $app"
 done
-
-# Enable the app under test.
 if [ -n "${APP_ID:-}" ]; then
 	echo "[enable-app] enabling app under test: $APP_ID"
-	if ! occ app:enable "$APP_ID"; then
-		echo "[enable-app] FAILED to enable '$APP_ID'."
-		echo "[enable-app] Is the frontend built (js/ present) and the Nextcloud version within the app's min/max range?"
-	fi
+	occ app:enable "$APP_ID" || echo "[enable-app] FAILED to enable '$APP_ID' (frontend built? version in range?)."
+fi
+
+# Minimal mode: disable every enabled app except the ones needed to test APP_ID.
+# Runs once on a fresh install (post-installation hook) or on demand
+# (FORCE_MINIMAL=1). Core apps that cannot be disabled (files, dav, settings,
+# theming, ...) are skipped silently -- that's the irreducible minimum.
+if [ "${MINIMAL_APPS:-false}" = "true" ]; then
+	case "${FORCE_MINIMAL:-}${0}" in
+	1* | *post-installation*)
+		echo "[enable-app] MINIMAL_APPS=true -> disabling apps not needed to test ${APP_ID:-the app}"
+		keep=" ${APP_ID:-} ${EXTRA_APPS:-} ${KEEP_APPS:-} "
+		enabled=$(occ app:list --output=json 2>/dev/null \
+			| php -r '$d=json_decode(stream_get_contents(STDIN),true); echo implode(" ", array_keys($d["enabled"] ?? []));')
+		for app in $enabled; do
+			case "$keep" in *" $app "*) continue ;; esac
+			occ app:disable "$app" >/dev/null 2>&1 && echo "[enable-app] disabled $app" || true
+		done
+		;;
+	esac
 fi

--- a/docker/hooks/enable-app.sh
+++ b/docker/hooks/enable-app.sh
@@ -59,3 +59,23 @@ if [ "${MINIMAL_APPS:-false}" = "true" ]; then
 		;;
 	esac
 fi
+
+# Optionally create ONE external storage mount (idempotent). Driven entirely by
+# env so the stack stays app-agnostic; .env pre-fills the CIDgravity defaults.
+# Skipped unless EXT_STORAGE_MOUNT is set. Config values must not contain spaces.
+if [ -n "${EXT_STORAGE_MOUNT:-}" ]; then
+	exists=$(occ files_external:list --output=json 2>/dev/null | php -r '
+		$d = json_decode(stream_get_contents(STDIN), true) ?: [];
+		$mp = "/" . getenv("EXT_STORAGE_MOUNT");
+		foreach ($d as $m) { if (($m["mount_point"] ?? "") === $mp) { echo "yes"; break; } }')
+	if [ "$exists" = "yes" ]; then
+		echo "[enable-app] external storage '$EXT_STORAGE_MOUNT' already exists; leaving it."
+	else
+		echo "[enable-app] creating external storage '$EXT_STORAGE_MOUNT' (${EXT_STORAGE_BACKEND:-cidgravity})"
+		( set --
+		  for kv in ${EXT_STORAGE_CONFIG:-}; do set -- "$@" -c "$kv"; done
+		  occ files_external:create "$EXT_STORAGE_MOUNT" \
+			"${EXT_STORAGE_BACKEND:-cidgravity}" "${EXT_STORAGE_AUTH:-password::password}" "$@"
+		) || echo "[enable-app] could not create external storage '$EXT_STORAGE_MOUNT'"
+	fi
+fi

--- a/docker/hooks/enable-app.sh
+++ b/docker/hooks/enable-app.sh
@@ -77,22 +77,29 @@ if [ "${MINIMAL_APPS:-false}" = "true" ]; then
 	esac
 fi
 
-# Optionally create ONE external storage mount (idempotent). Driven entirely by
-# env so the stack stays app-agnostic; .env pre-fills the CIDgravity defaults.
-# Skipped unless EXT_STORAGE_MOUNT is set. Config values must not contain spaces.
-if [ -n "${EXT_STORAGE_MOUNT:-}" ]; then
-	exists=$(occ files_external:list --output=json 2>/dev/null | php -r '
-		$d = json_decode(stream_get_contents(STDIN), true) ?: [];
-		$mp = "/" . getenv("EXT_STORAGE_MOUNT");
-		foreach ($d as $m) { if (($m["mount_point"] ?? "") === $mp) { echo "yes"; break; } }')
-	if [ "$exists" = "yes" ]; then
-		echo "[enable-app] external storage '$EXT_STORAGE_MOUNT' already exists; leaving it."
+# Optionally create external storage mounts (idempotent). Define up to a few
+# mounts via indexed env vars EXT_STORAGE_<i>_{MOUNT,BACKEND,AUTH,CONFIG};
+# iteration stops at the first empty MOUNT. Generic (any backend) so the stack
+# stays app-agnostic. Config is space-separated key=value (no spaces in values).
+existing=$(occ files_external:list --output=json 2>/dev/null \
+	| php -r '$d=json_decode(stream_get_contents(STDIN),true) ?: []; foreach($d as $m){ echo ($m["mount_point"] ?? "")."\n"; }')
+i=1
+while :; do
+	eval "mount=\${EXT_STORAGE_${i}_MOUNT:-}"
+	[ -z "$mount" ] && break
+	eval "backend=\${EXT_STORAGE_${i}_BACKEND:-cidgravity}"
+	eval "auth=\${EXT_STORAGE_${i}_AUTH:-password::password}"
+	eval "config=\${EXT_STORAGE_${i}_CONFIG:-}"
+	if printf '%s\n' "$existing" | grep -Fxq "/$mount"; then
+		echo "[enable-app] external storage '$mount' already exists; leaving it."
+	elif ( set --
+		for kv in $config; do set -- "$@" -c "$kv"; done
+		echo "[enable-app] creating external storage '$mount' ($backend)"
+		occ files_external:create "$mount" "$backend" "$auth" "$@" ); then
+		existing="$existing
+/$mount"
 	else
-		echo "[enable-app] creating external storage '$EXT_STORAGE_MOUNT' (${EXT_STORAGE_BACKEND:-cidgravity})"
-		( set --
-		  for kv in ${EXT_STORAGE_CONFIG:-}; do set -- "$@" -c "$kv"; done
-		  occ files_external:create "$EXT_STORAGE_MOUNT" \
-			"${EXT_STORAGE_BACKEND:-cidgravity}" "${EXT_STORAGE_AUTH:-password::password}" "$@"
-		) || echo "[enable-app] could not create external storage '$EXT_STORAGE_MOUNT'"
+		echo "[enable-app] could not create external storage '$mount'"
 	fi
-fi
+	i=$((i + 1))
+done

--- a/docker/hooks/enable-app.sh
+++ b/docker/hooks/enable-app.sh
@@ -41,6 +41,23 @@ if [ -n "${APP_ID:-}" ]; then
 	occ app:enable "$APP_ID" || echo "[enable-app] FAILED to enable '$APP_ID' (frontend built? version in range?)."
 fi
 
+# Optionally set Nextcloud system config on boot (idempotent). Space-separated
+# key=value pairs (values must not contain spaces); type is inferred:
+# true/false -> boolean, all-digits -> integer, everything else -> string.
+# e.g. NC_CONFIG="cidgravity_gateway_external_storage_enabled=true loglevel=0"
+for kv in ${NC_CONFIG:-}; do
+	key=${kv%%=*}
+	val=${kv#*=}
+	case "$val" in
+	true | false) type=boolean ;;
+	'' | *[!0-9]*) type=string ;;
+	*) type=integer ;;
+	esac
+	echo "[enable-app] config:system:set $key ($type) = $val"
+	occ config:system:set "$key" --value="$val" --type="$type" >/dev/null \
+		|| echo "[enable-app] could not set system config: $key"
+done
+
 # Minimal mode: disable every enabled app except the ones needed to test APP_ID.
 # Runs once on a fresh install (post-installation hook) or on demand
 # (FORCE_MINIMAL=1). Core apps that cannot be disabled (files, dav, settings,


### PR DESCRIPTION
Add a disposable, reusable Docker Compose stack (Nextcloud + PostgreSQL + Redis) under docker/ to test the app against a real Nextcloud without a permanent dev server. The repo is mounted into custom_apps/ and the app (plus its files_external dependency) is auto-enabled on boot via an entrypoint hook. Parameterized through .env (NEXTCLOUD_VERSION, APP_ID, EXTRA_APPS) so it can be copied into any other Nextcloud app repo.

Also add docker-* Makefile targets (up/down/stop/restart/logs/ps/occ/ shell/clean) and exclude docker/ from the appstore package (Makefile + .nextcloudignore).