### PR TITLE
feat(docker): add docker-reset to apply .env changes from a clean DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,13 @@ docker-minimal:
 docker-clean:
 	$(docker_compose) down -v
 
+# Apply a changed .env from scratch: wipe volumes (DB + data), then reinstall.
+# Use this after editing EXT_STORAGE_* / DB / admin values, which live in the DB
+# and are otherwise kept across docker-down/up.
+docker-reset: docker-env
+	$(docker_compose) down -v
+	$(docker_compose) up -d
+
 create-tag:
 	git tag -a v$(version) -m "Tagging the $(version) release."
 	git push origin v$(version)

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,6 +48,29 @@ From the repo root (these wrap the `docker compose` commands below):
 | `make docker-shell` | Open a shell in the Nextcloud container as `www-data` |
 | `make docker-minimal` | Disable every app not needed to test the app (lighter instance) |
 | `make docker-clean` | Tear down **including data volumes** (next up = clean install) |
+| `make docker-reset` | Wipe volumes **and** start fresh — apply changed `.env` from scratch |
+
+### Applying `.env` changes
+
+`docker-down`/`docker-up` keep the volumes, and a lot of state lives in the
+**database** — enabled apps, system config, and external-storage mounts. So:
+
+- **System config (`NC_CONFIG`) and app enable/minimal** are re-applied on every
+  boot, so `make docker-up` (which recreates the container with the new env)
+  picks those up.
+- **External-storage mounts (`EXT_STORAGE_*`)** are created idempotently — an
+  existing mount is *kept*, so editing its credentials/URLs in `.env` does **not**
+  update the mount already in the DB. New mount names (new slots) are created on
+  the next `docker-up`, but changes to existing ones need a clean DB.
+
+To apply changed `EXT_STORAGE_*` (or DB/admin values), reset from scratch:
+
+```sh
+make docker-reset      # = down -v && up -d
+```
+
+(Or edit the mount directly in the UI / `make docker-occ CMD="files_external:..."`
+if you don't want to wipe the instance.)
 
 ## Testing the app
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -136,8 +136,9 @@ Notes:
 
 ## Minimal instance
 
-To keep the instance light, `MINIMAL_APPS=true` (the default in `.env.example`)
-disables every default/onboarding/sharing app that isn't needed to test the app
+To keep the instance light, `MINIMAL_APPS` is **on by default** (set
+`MINIMAL_APPS=false` to opt out). It disables every default/onboarding/sharing
+app that isn't needed to test the app
 — dashboard, firstrunwizard, activity, photos, text, files_sharing, etc. Only
 the app under test (`APP_ID`), its dependencies (`EXTRA_APPS`), anything in
 `KEEP_APPS`, and Nextcloud's always-enabled core (files, dav, settings, theming,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       # --- Read by the enable-app.sh entrypoint hook (runs inside this container) ---
       APP_ID: ${APP_ID:-cidgravity}
       EXTRA_APPS: ${EXTRA_APPS:-files_external}
-      MINIMAL_APPS: ${MINIMAL_APPS:-false}
+      MINIMAL_APPS: ${MINIMAL_APPS:-true}
       KEEP_APPS: ${KEEP_APPS:-}
       # Optional: Nextcloud system config to set on boot (key=value pairs).
       NC_CONFIG: ${NC_CONFIG:-}


### PR DESCRIPTION
docker-down/up keep the volumes, and external-storage mounts live in the database, so the idempotent boot hook keeps an existing mount and edited EXT_STORAGE_* credentials in .env never apply. Add `make docker-reset` (down -v && up -d) to reinstall from scratch, and document which .env changes apply on a plain docker-up vs. which need a reset.