### PR TITLE
fix(renovate): match php constraint via matchDepNames so the floor gu…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,9 +91,9 @@
       "enabled": false
     },
     {
-      "description": "Don't bump the PHP floor — composer.json `php ^8.2` is a deliberate min-version statement tied to the Nextcloud versions we support, not something to drift with each new PHP release.",
-      "matchPackageNames": ["php"],
+      "description": "Don't bump the PHP floor — composer.json `php ^8.2` is a deliberate min-version statement tied to the Nextcloud versions we support, not something to drift with each new PHP release. Match on matchDepNames (not matchPackageNames): the composer manager gives the php constraint packageName `php/php-src`, so matchPackageNames:[\"php\"] never fires; depName stays `php`.",
       "matchManagers": ["composer"],
+      "matchDepNames": ["php"],
       "enabled": false
     },
     {


### PR DESCRIPTION
…ard actually fires

The "don't bump the PHP floor" rule used matchPackageNames:["php"], which never matched: the composer manager assigns the php constraint packageName `php/php-src` (GitHub tags) while keeping depName `php`, and matchPackageNames matches on packageName. So php fell through to the "Composer dependencies" group and got bumped ^8.2 -> ^8.5.6, which then broke composer.lock artifact updates against the fixed platform.php=8.2 override. Switch to matchDepNames:["php"] which exact-matches the manifest name.